### PR TITLE
Avoid the use of artifacts with security vulnerabilities

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        os: [ ubuntu-latest, macos-13, windows-latest ]
 
     runs-on: ${{ matrix.os }}
 
@@ -113,7 +113,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        os: [ ubuntu-latest, macos-13, windows-latest ]
 
     runs-on: ${{ matrix.os }}
 

--- a/jvm/build.gradle.kts
+++ b/jvm/build.gradle.kts
@@ -32,13 +32,13 @@ repositories {
 }
 
 dependencies {
-    implementation("org.bouncycastle:bcprov-jdk15on:1.70")
-    implementation("org.bouncycastle:bcpkix-jdk15on:1.70")
-    implementation("org.bouncycastle:bcutil-jdk15on:1.70")
+    implementation("org.bouncycastle:bcprov-jdk18on:1.78.1")
+    implementation("org.bouncycastle:bcpkix-jdk18on:1.78.1")
+    implementation("org.bouncycastle:bcutil-jdk18on:1.78.1")
     implementation("org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:1.7.3")
-    implementation("org.apache.commons:commons-compress:1.21")
+    implementation("org.apache.commons:commons-compress:1.26.1")
 
     testImplementation("org.junit.jupiter:junit-jupiter-params:$junitVersion")
     testImplementation("org.junit.jupiter:junit-jupiter-api:$junitVersion")

--- a/jvm/src/main/kotlin/com/jetbrains/signatureverifier/bouncycastle/cms/CMSSignedHelper.kt
+++ b/jvm/src/main/kotlin/com/jetbrains/signatureverifier/bouncycastle/cms/CMSSignedHelper.kt
@@ -30,13 +30,13 @@ import org.bouncycastle.util.Store
 internal class CMSSignedHelper {
   /**
    * Return the digest encryption algorithm using one of the standard
-   * JCA string representations rather the the algorithm identifier (if
+   * JCA string representations rather the algorithm identifier (if
    * possible).
    */
   fun getEncryptionAlgName(
     encryptionAlgOID: String
   ): String {
-    val algName = encryptionAlgs[encryptionAlgOID] as String?
+    val algName = encryptionAlgs[encryptionAlgOID]
     return algName ?: encryptionAlgOID
   }
 
@@ -75,7 +75,7 @@ internal class CMSSignedHelper {
       while (en.hasMoreElements()) {
         val obj = (en.nextElement() as ASN1Encodable).toASN1Primitive()
         if (obj is ASN1TaggedObject) {
-          certList.add(X509AttributeCertificateHolder(AttributeCertificate.getInstance(obj.getObject())))
+          certList.add(X509AttributeCertificateHolder(AttributeCertificate.getInstance(obj.baseObject)))
         }
       }
       return CollectionStore(certList)


### PR DESCRIPTION
Currently we have version 1.1.1 in Maven Central https://mvnrepository.com/artifact/com.jetbrains.format-ripper/format-ripper/1.1.1 that contains a number of security vulnerabilities which are coming from the use of outdated Apache Commons and Bouncy castle dependencies. This pull request attempts to fix that.