### PR TITLE
NP-1716 Updated BouncyCastle 2.2.1 => 2.4.0.

### DIFF
--- a/net/JetBrains.FormatRipper/src/JetBrains.FormatRipper.csproj
+++ b/net/JetBrains.FormatRipper/src/JetBrains.FormatRipper.csproj
@@ -16,7 +16,7 @@
     <PackageTags>jetbrains compound elf mach-o msi pe dmg parse windows linux macos netstandard netframework</PackageTags>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-    <Version>2.2.0</Version>
+    <Version>2.2.1</Version>
     <PackageProjectUrl>https://github.com/JetBrains/format-ripper</PackageProjectUrl>
   </PropertyGroup>
   <ItemGroup>

--- a/net/JetBrains.FormatRipper/tests/JetBrains.FormatRipper.Tests.csproj
+++ b/net/JetBrains.FormatRipper/tests/JetBrains.FormatRipper.Tests.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="NUnit" Version="3.14.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="All" />
     <ProjectReference Include="..\src\JetBrains.FormatRipper.csproj" />
   </ItemGroup>

--- a/net/JetBrains.SignatureVerifier/src/JetBrains.SignatureVerifier.csproj
+++ b/net/JetBrains.SignatureVerifier/src/JetBrains.SignatureVerifier.csproj
@@ -15,11 +15,11 @@
     <PackageTags>jetbrains signature verify netstandard</PackageTags>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-    <Version>2.2.0</Version>
+    <Version>2.2.1</Version>
     <PackageProjectUrl>https://github.com/JetBrains/format-ripper</PackageProjectUrl>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="BouncyCastle.Cryptography" Version="2.2.1" />
+    <PackageReference Include="BouncyCastle.Cryptography" Version="2.4.0" />
     <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All" />
     <ProjectReference Include="..\..\JetBrains.FormatRipper\src\JetBrains.FormatRipper.csproj" />
   </ItemGroup>

--- a/net/JetBrains.SignatureVerifier/tests/JetBrains.SignatureVerifier.Tests.csproj
+++ b/net/JetBrains.SignatureVerifier/tests/JetBrains.SignatureVerifier.Tests.csproj
@@ -8,12 +8,12 @@
     <LangVersion>10</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="BouncyCastle.Cryptography" Version="2.2.1" />
+    <PackageReference Include="BouncyCastle.Cryptography" Version="2.4.0" />
     <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All" />
     <PackageReference Include="Moq" Version="4.20.70" />
     <PackageReference Include="NUnit" Version="3.14.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <ProjectReference Include="..\src\JetBrains.SignatureVerifier.csproj" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Bumped versions of FormatRipper and SignatureVerifier to 2.2.1.
Updated Microsoft.NET.Test.Sdk 17.8.0 => 17.10.0 as well